### PR TITLE
Symlink to folder not karabiner.json

### DIFF
--- a/mackup/applications/karabiner-elements.cfg
+++ b/mackup/applications/karabiner-elements.cfg
@@ -2,4 +2,4 @@
 name = Karabiner Elements
 
 [configuration_files]
-.config/karabiner/karabiner.json
+.config/karabiner/


### PR DESCRIPTION
https://pqrs.org/osx/karabiner/document.html#configuration-file-path
Do not make a symlink to karabiner.json.
Karabiner-Elements does not reload the configuration file properly if you make a symlink to json file directly.